### PR TITLE
Fix logger reference in SearchViewModel

### DIFF
--- a/OSINTScout/ViewModels/SearchViewModel.swift
+++ b/OSINTScout/ViewModels/SearchViewModel.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+final class SearchViewModel {
+    private let logger: Logger
+
+    init(logger: Logger) {
+        self.logger = logger
+    }
+
+    func execute(entity: SearchEntity) {
+        let logger = self.logger
+        logger.log(entity)
+    }
+}
+
+protocol Logger {
+    func log(_ entity: SearchEntity)
+}
+
+struct SearchEntity {}


### PR DESCRIPTION
## Summary
- ensure the execute(entity:) method uses the instance logger instead of shadowing it

## Testing
- not run (Xcode is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68db237ebe88832286cf41b228e384d7