### PR TITLE
Add sqlite transient binding helper

### DIFF
--- a/OSINTScout/Storage/Cache.swift
+++ b/OSINTScout/Storage/Cache.swift
@@ -1,0 +1,22 @@
+import Foundation
+import SQLite3
+
+private let sqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+final class Cache {
+    private let statement: OpaquePointer?
+
+    init(statement: OpaquePointer?) {
+        self.statement = statement
+    }
+
+    func bind(text: String, at index: Int32) {
+        sqlite3_bind_text(statement, index, text, -1, sqliteTransient)
+    }
+
+    func bind(data: Data, at index: Int32) {
+        data.withUnsafeBytes { buffer in
+            sqlite3_bind_blob(statement, index, buffer.baseAddress, Int32(buffer.count), sqliteTransient)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `sqliteTransient` constant alongside the imports in `Cache.swift`
- switch the text and blob binding helpers to use the new descriptor instead of `SQLITE_TRANSIENT`

## Testing
- swiftc OSINTScout/Storage/Cache.swift -o /tmp/cache *(fails: no such module 'SQLite3')*


------
https://chatgpt.com/codex/tasks/task_e_68dc0fdcaef88322ab402d45fe7b48d0